### PR TITLE
Refactor api loader

### DIFF
--- a/modules/api_loader.lua
+++ b/modules/api_loader.lua
@@ -9,73 +9,200 @@ local function get_name(xml_element)
     end
     return name
 end
+ 
 
-local function loadEnums(api, dest)
-  local enums = api:xpath("//interface/enum")
-  for _, e in ipairs(enums) do
-    local enum = { }
-    local i = 1
-    for _, item in ipairs(e:children("element")) do
-      enum[item:attr("name")] = i
-      i = i + 1
+local function LoadResultCodes( param )
+  local resultCodes ={}
+  local i = 1
+  for _, item in ipairs(param:children("element")) do
+     local name = item:attr("name")
+     resultCodes[i]=name
+     i=i + 1
     end
-    dest.enum[get_name(e)] = enum
-  end
+  return resultCodes
 end
 
-local function loadStructs(api, dest)
-  local structs = api:xpath("//interface/struct")
-  for _, s in ipairs(structs) do
-    local struct = { }
-    for _, item in ipairs(s:children("param")) do
-      struct[item:attr("name")] = item:attributes()
-    end
-    dest.struct[get_name(s)] = struct
+local function LoadParamsInFunction(param, interface)
+  local name = param:attr("name")
+  local p_type = param:attr("type")
+  local minlength = param:attr("minlength")
+  local maxlength = param:attr("maxlength")
+  local minsize =  param:attr("minsize")
+  local maxsize = param:attr("maxsize")
+  local mandatory = param:attr("mandatory")
+  local array = param:attr("array")
+
+  if mandatory == nil then 
+    mandatory = true
   end
 
-  for n, s in pairs(dest.struct) do
-    for _, p in pairs(s) do
-      if type(p.type) == 'string' then
-        if p.type == "Integer" then
-          p.class = dest.classes.Integer
-        elseif p.type == "String" then
-          p.class = dest.classes.String
-        elseif p.type == "Float" then
-          p.class = dest.classes.Float
-        elseif p.type == "Boolean" then
-          p.class = dest.classes.Boolean
-        elseif dest.enum[p.type] then
-          p.class = dest.classes.Enum
-          p.type = dest.enum[p.type]
-        elseif dest.struct[p.type] then
-          p.class = dest.classes.Struct
-          p.type = dest.struct[p.type]
-        end
+  if array == nil then 
+    array = false
+  end
+
+  local result_codes = nil
+  if name == "resultCode" and p_type == "Result" then 
+    result_codes  = LoadResultCodes(param) 
+  end
+  local data = {}
+  data["type"]=p_type
+  data["mandatory"]= mandatory
+  data["array"] = array
+  data["minlength"] = minlength
+  data["maxlength"] = maxlength
+  data["minsize"] = minsize
+  data["maxsize"] = maxsize
+  data["resultCodes"] = result_codes
+  return name, data
+end
+
+
+
+ local function LoadEnums(api, dest)
+   local enums = api:xpath("//interface/enum")
+   for _, e in ipairs(enums) do
+     local enum = { }
+     local i = 1
+     for _, item in ipairs(e:children("element")) do
+       enum[item:attr("name")] = i
+       i = i + 1
+     end
+     dest.enum[get_name(e)] = enum
+   end
+
+   for first, v in pairs (dest.interface) do
+    for _, s in ipairs(v.body:children("enum")) do
+      local name = s:attr("name")
+      dest.interface[first].enum[name]={}
+      local i = 1
+      for _,e in ipairs(s:children("element")) do
+        local enum_value = e:attr("name")
+        dest.interface[first].enum[name][enum_value]=i
+        i= i + 1
       end
     end
   end
+ end
+ 
+ local function LoadStructs(api, dest)
+   for first, v in pairs (dest.interface) do
+    for _, s in ipairs(v.body:children("struct")) do
+
+      local name = s:attr("name")
+      local temp_param = {}
+      local temp_func = {}
+      temp_func["name"] = name
+      for _, item in ipairs(s:children("param")) do
+        param_name, param_data = LoadParamsInFunction(item, first)
+        temp_param[param_name] = param_data
+      end
+      temp_func["param"] = temp_param
+      dest.interface[first].struct[name]=temp_func
+    end
+   end
+
+   local structs = api:xpath("//interface/struct")
+   for _, s in ipairs(structs) do
+     local struct = { }
+     for _, item in ipairs(s:children("param")) do
+       struct[item:attr("name")] = item:attributes()
+     end
+     dest.struct[get_name(s)] = struct
+   end
+ 
+   for n, s in pairs(dest.struct) do
+     for _, p in pairs(s) do
+       if type(p.type) == 'string' then
+         if p.type == "Integer" then
+           p.class = dest.classes.Integer
+         elseif p.type == "String" then
+           p.class = dest.classes.String
+         elseif p.type == "Float" then
+           p.class = dest.classes.Float
+         elseif p.type == "Boolean" then
+           p.class = dest.classes.Boolean
+         elseif dest.enum[p.type] then
+           p.class = dest.classes.Enum
+           p.type = dest.enum[p.type]
+         elseif dest.struct[p.type] then
+           p.class = dest.classes.Struct
+           p.type = dest.struct[p.type]
+         end
+       end
+     end
+   end
+ end
+ 
+
+
+
+
+local function LoadFunction( api, dest  )
+  for first, v in pairs (dest.interface) do
+    for _, s in ipairs(v.body:children("function")) do
+      local name = s:attr("name")
+      local msg_type = s:attr("messagetype")
+      local temp_func = {}
+      local temp_param = {}
+      temp_func["name"] = name
+      temp_func["messagetype"] = msg_type
+      for _, item in ipairs(s:children("param")) do
+        param_name, param_data = LoadParamsInFunction(item, first)
+        temp_param[param_name] = param_data
+      end
+
+      temp_func["param"] = temp_param
+      dest.interface[first].type[msg_type].functions[name]=temp_func
+    end
+  end
+
 end
 
-function module.init(path, include_parent_name)
-  module.include_parent_name = include_parent_name
-  local result = {}
-  result.classes = {
-    String = { },
-    Integer = { },
-    Float = { },
-    Boolean = { },
-    Struct = { },
-    Enum = { }
-  }
-  result.enum = { }
-  result.struct = { }
-
-  local _api = xml.open(path)
-  if not _api then error(path .. " not found") end
-
-  loadEnums(_api, result)
-  loadStructs(_api, result)
-  return result
+local function LoadInterfaces( api, dest )
+  local interfaces = api:xpath("//interface")
+  for _, s in ipairs(interfaces) do
+    name = s:attr("name")
+    dest.interface[name] ={}
+    dest.interface[name].body = s
+    dest.interface[name].type={}
+    dest.interface[name].type['request']={}
+    dest.interface[name].type['request'].functions={}
+    dest.interface[name].type['response']={}
+    dest.interface[name].type['response'].functions={}
+    dest.interface[name].type['notification']={}
+    dest.interface[name].type['notification'].functions={}
+    dest.interface[name].enum={}
+    dest.interface[name].struct={}
+  end
 end
 
-return module
+
+ function module.init(path, include_parent_name)
+   module.include_parent_name = include_parent_name
+   local result = {}
+   result.classes = {
+     String = { },
+     Integer = { },
+     Float = { },
+     Boolean = { },
+     Struct = { },
+     Enum = { }
+   }
+   result.enum = { }
+   result.struct = { }
+  result.interface = { }
+ 
+  module.msg_type = {'request', 'response', 'notification'}
+   local _api = xml.open(path)
+   if not _api then error(path .. " not found") end
+ 
+  LoadInterfaces(_api, result)
+   LoadEnums(_api, result)
+   LoadStructs(_api, result)
+
+  LoadFunction(_api, result)
+
+   return result
+ end
+ 
+ return module

--- a/modules/connecttest.lua
+++ b/modules/connecttest.lua
@@ -10,7 +10,12 @@ local events = require("events")
 local expectations = require('expectations')
 local functionId = require('function_id')
 local SDL = require('SDL')
-local validator = require('schema_validation')
+
+local load_schema = require('load_schema')
+
+local mob_schema = load_schema.mob_schema
+local hmi_schema = load_schema.hmi_schema
+
 local Event = events.Event
 
 local Expectation = expectations.Expectation
@@ -57,7 +62,7 @@ function module.hmiConnection:EXPECT_HMIRESPONSE(id, args)
       local _res, _err
       _res = true
       if not (table2str(arguments):match('error')) then
-        _res, _err = validator.validate_hmi_response(func_name, results_args2)
+        _res, _err = hmi_schema:Validate(func_name,"HMI", 'response', results_args2)
       end
       if (not _res) then
         return _res,_err
@@ -96,7 +101,7 @@ function EXPECT_HMINOTIFICATION(name,...)
         module.notification_counter = module.notification_counter + 1
         xmlReporter.AddMessage("EXPECT_HMINOTIFICATION", {["Id"] = correlation_id, ["name"] = tostring(name),["Type"] = "EXPECTED_RESULT"},arguments)
         xmlReporter.AddMessage("EXPECT_HMINOTIFICATION", {["Id"] = correlation_id, ["name"] = tostring(name),["Type"] = "AVALIABLE_RESULT"},data)
-        local _res, _err = validator.validate_hmi_notification(name, arguments)
+        local _res, _err = hmi_schema:Validate(name,"HMI", 'notification', arguments)
         if (not _res) then return _res,_err end
         return compareValues(arguments, data.params, "params")
       end)
@@ -124,7 +129,7 @@ function EXPECT_HMICALL(methodName, ...)
         end
         xmlReporter.AddMessage("EXPECT_HMICALL", {["Id"] = data.id, ["name"] = tostring(methodName),["Type"] = "EXPECTED_RESULT"},arguments)
         xmlReporter.AddMessage("EXPECT_HMICALL", {["Id"] = data.id, ["name"] = tostring(methodName),["Type"] = "AVALIABLE_RESULT"},data.params)
-        _res, _err = validator.validate_hmi_request(methodName, arguments)
+        _res, _err = hmi_schema:Validate(methodName,"HMI", 'request', arguments)
         if (not _res) then return _res,_err end
         return compareValues(arguments, data.params, "params")
       end)
@@ -171,7 +176,7 @@ function EXPECT_ANY_SESSION_NOTIFICATION(funcName, ...)
         else
           arguments = args[self.occurences]
         end
-        local _res, _err = validator.validate_mobile_notification(funcName, arguments)
+        local _res, _err = mob_schema:Validate(funcName,"MOBILE", 'notification', arguments)
         xmlReporter.AddMessage("EXPECT_ANY_SESSION_NOTIFICATION", {["name"] = tostring(funcName),["Type"]= "EXPECTED_RESULT"}, arguments)
         xmlReporter.AddMessage("EXPECT_ANY_SESSION_NOTIFICATION", {["name"] = tostring(funcName),["Type"]= "AVALIABLE_RESULT"}, data.payload)
         if (not _res) then return _res,_err end

--- a/modules/load_schema.lua
+++ b/modules/load_schema.lua
@@ -1,0 +1,11 @@
+local api_loader = require('api_loader')
+local validator = require('schema_validation')
+
+local module = { }
+if (not module.mob_schema) then 
+module.mob_schema = validator.CreateSchemaValidator(api_loader.init("data/MOBILE_API.xml"))
+end
+if (not module.hmi_schema) then
+module.hmi_schema = validator.CreateSchemaValidator(api_loader.init("data/HMI_API.xml", true))
+end
+return module

--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -5,7 +5,10 @@ local functionId = require('function_id')
 local json = require('json')
 local expectations = require('expectations')
 local constants = require('protocol_handler/ford_protocol_constants')
-local validator = require('schema_validation')
+local load_schema = require('load_schema')
+
+local mob_schema = load_schema.mob_schema
+
 local Expectation = expectations.Expectation
 local Event = events.Event
 local SUCCESS = expectations.SUCCESS
@@ -77,7 +80,7 @@ function mt.__index:ExpectResponse(cor_id, ...)
         end
         xmlReporter.AddMessage("EXPECT_RESPONSE",{["id"] = tostring(cor_id),["name"] = tostring(func_name),["Type"]= "EXPECTED_RESULT"}, arguments)
         xmlReporter.AddMessage("EXPECT_RESPONSE",{["id"] = tostring(cor_id),["name"] = tostring(func_name),["Type"]= "AVALIABLE_RESULT"}, data.payload)
-        local _res, _err = validator.validate_mobile_response(func_name, arguments)
+        local _res, _err = mob_schema:Validate(func_name,"MOBILE", 'response', arguments)
         if (not _res) then return _res,_err end
         return compareValues(arguments, data.payload, "payload")
       end)
@@ -130,8 +133,8 @@ function mt.__index:ExpectNotification(funcName, ...)
         xmlReporter.AddMessage("EXPECT_NOTIFICATION",{["Id"] = module.notification_counter, 
           ["name"] = tostring(funcName),["Type"]= "EXPECTED_RESULT"}, arguments)
         xmlReporter.AddMessage("EXPECT_NOTIFICATION",{["Id"] = module.notification_counter, 
-          ["name"] = tostring(funcName),["Type"]= "AVALIABLE_RESULT"}, data.payload)
-        local _res, _err = validator.validate_mobile_notification(funcName, arguments)
+          ["name"] = tostring(funcName),["Type"]= "AVALIABLE_RESULT"}, data.payload)      
+        local _res, _err = mob_schema:Validate(funcName,"MOBILE", 'notification', arguments)
         if (not _res) then
           return _res,_err
         end

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -15,6 +15,13 @@ local module = {
   MOBILE= 2
 }
 
+function module.CreateSchemaValidator(schema)
+  res = { }
+ res.schema = schema
+  setmetatable(res, module.mt)
+  return res
+end
+
 local function dump(o)
   if type(o) == 'table' then
     local s = '{ '
@@ -79,7 +86,6 @@ function module.json_validate(table1, table2)
 end
 
 local function compare(schema, function_id, msgType, user_data, mandatory_check)
-
   local doc = ''
   local bool_result = true
   local errorMessage = {}
@@ -325,28 +331,19 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
   return schemaCompare(xml_schema,user_data)
 end
 
-function module.validate_hmi_request(function_id,user_data, mandatory_check)
-  return compare(module.HMI, function_id, 'request', user_data, mandatory_check)
-end
 
-function module.validate_mobile_request(function_id,user_data, mandatory_check)
-  return compare(module.MOBILE,function_id, 'request',user_data, mandatory_check)
-end
 
-function module.validate_hmi_response(function_id,user_data, mandatory_check)
-  return compare(module.HMI,function_id, 'response',user_data, mandatory_check)
-end
 
-function module.validate_mobile_response(function_id,user_data, mandatory_check)
-  return compare(module.MOBILE,function_id, 'response',user_data, mandatory_check)
-end
+function module.mt.__index:Validate(function_id, api_type, function_type, user_data, mandatory_check)
+  local result = true
+  local errorMessage = {}
 
-function module.validate_mobile_notification(function_id,user_data, mandatory_check)
-  return compare(module.MOBILE,function_id, 'notification',user_data, mandatory_check)
-end
-
-function module.validate_hmi_notification(function_id,user_data, mandatory_check)
-  return compare(module.HMI,function_id, 'notification',user_data, mandatory_check)
-end
+  if (api_type == "MOBILE") then
+    result, errorMessage = compare(module.MOBILE,function_id, function_type, user_data, mandatory_check)    
+  else
+    result, errorMessage = compare(module.HMI,function_id, function_type, user_data, mandatory_check)  
+  end
+    return result, errorMessage
+  end
 
 return module


### PR DESCRIPTION
Change structure of API loader. Interfaces, functions, enums, and structures are loaded in table and will be used by schema validation. 
All components now can use only one function for validation. it has argument (which api is used - HMI or Mobile, ) that will be removed after refactoring of compare method.

Related to [APPLINK-16779](https://adc.luxoft.com/jira/browse/APPLINK-16779)
Please review @Kozoriz, @LuxoftAKutsan, @OHerasym, 
